### PR TITLE
Find people lying in the request agreement

### DIFF
--- a/.github/ISSUE_TEMPLATE/request.yml
+++ b/.github/ISSUE_TEMPLATE/request.yml
@@ -58,5 +58,7 @@ body:
           required: true
         - label: "I checked the [existing plugins](https://vencord.dev/plugins) and made sure my plugin doesn't already exist"
           required: true
+        - label: I checked every box, despite not reading any
+          required: false
         - label: "I [searched the existing issues](https://github.com/Vencord/plugin-requests/issues?q=is%3Aissue) and made sure a similar request doesn't already exist"
           required: true


### PR DESCRIPTION
This PR adds an optional checkbox labeled "I checked every box, despite not reading any" into the plugin request template. I saw this on the purpur repository and thought it would fit this repo well (since there's so many rejected requests) as a good way to filter out "bad" issues.

If you feel like this doesn't fit plugin requests, this might also work on the main vencord repository.